### PR TITLE
fix: Deprecated `set-output` issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  workflow_dispatch:
   pull_request:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/publish.yml
       - Dockerfile
       - action.yml
       - src/docker-entrypoint.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - Dockerfile
+      - action.yml
+      - src/docker-entrypoint.sh
 
 env:
   REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: validate
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,5 +47,6 @@ jobs:
         run: |
           ./scripts/update-readme.sh
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
+            git commit -m "docs: README.md Updated"
             git push
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,5 +37,6 @@ jobs:
         run: |
           ./scripts/update-readme.sh
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
+            git diff --compact-summary
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,18 @@ jobs:
           sudo chmod 755 /usr/local/bin/gomplate
 
       - name: Check README content based on action.yml
+        if: ${{ github.repository_owner == 'terraform-docs' }}
         run: |
           ./scripts/update-readme.sh
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
             git diff
             exit 1
+          fi
+
+      - name: Check README content based on action.yml
+        if: ${{ github.repository_owner != 'terraform-docs' }}
+        run: |
+          ./scripts/update-readme.sh
+          if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
+            git push
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,6 @@ jobs:
         run: |
           ./scripts/update-readme.sh
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
-            git diff --compact-summary
+            git diff
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           ./scripts/update-readme.sh
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
+            git config user.email "noreply.${{ github.actor }}@github.com"
+            git config user.name "${{ github.actor }}"
             git commit -m "docs: README.md Updated"
             git push
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
           if [ $(git status --porcelain | grep -c 'M README.md') -eq 1 ]; then
             git config user.email "noreply.${{ github.actor }}@github.com"
             git config user.name "${{ github.actor }}"
+            git add README.md
             git commit -m "docs: README.md Updated"
             git push
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,6 @@ jobs:
             git config user.email "noreply.${{ github.actor }}@github.com"
             git config user.name "${{ github.actor }}"
             git add README.md
-            git commit -m "docs: README.md Updated"
+            git commit -s -m "docs: README.md Updated"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ jobs:
 | indention | Indention level of Markdown sections [1, 2, 3, 4, 5] | `2` | false |
 | output-file | File in module directory where the docs should be placed | `README.md` | false |
 | output-format | terraform-docs format to generate content (see [all formats](https://github.com/terraform-docs/terraform-docs/blob/master/docs/FORMATS\_GUIDE.md)) (ignored if `config-file` is set) | `markdown table` | false |
-| output-method | Method should be one of `replace`, `inject`, or `print` | `inject` | false |
+| output-method | Method should be one of `replace`, `inject`, or `print`. Set as an empty string if `output.mode` and `output.file` are defined in config-file | `inject` | false |
 | recursive | If true it will update submodules recursively | `false` | false |
 | recursive-path | Submodules path to recursively update | `modules` | false |
-| template | When provided will be used as the template if/when the `output-file` does not exist | `<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->` | false |
+| template | When provided will be used as the template if/when the `output-file` does not exist. Set as an empty string if `output.template` is defined in config-file | `<!-- BEGIN_TF_DOCS -->\n{{ .Content }}\n<!-- END_TF_DOCS -->` | false |
 | working-dir | Comma separated list of directories to generate docs for (ignored if `atlantis-file` or `find-dir` is set) | `.` | false |
 
 #### Output Method (output-method)

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -177,7 +177,7 @@ fi
 set +e
 num_changed=$(git_status)
 set -e
-echo "num_changed=${num_changed}" >> $GITHUB_OUTPUT
+echo "num_changed=${num_changed}" >> "$GITHUB_OUTPUT"
 
 if [ "${INPUT_GIT_PUSH}" = "true" ]; then
     git_commit


### PR DESCRIPTION
### Description of your changes
Trying to get rid of the deprecated `set-output` issue.

fixes #109

I have:

- [x] Read and followed terraform-docs' [contribution process].

### How has this code been tested
I ended up changing some of the workflow files to do something different outside of your account but still using the same code inside of your account.  This allowed me to better test/run your validation steps externally.

[contribution process]: https://git.io/Jt3K5